### PR TITLE
Call nock.cleanAll() before throwing error

### DIFF
--- a/invite/test/github.test.ts
+++ b/invite/test/github.test.ts
@@ -43,8 +43,8 @@ describe.skip('GitHub interface', () => {
   afterEach(() => {
     // Fail the test if there were unused nocks.
     if(!nock.isDone()) {
-      throw new Error('Not all nock interceptors were used!');
       nock.cleanAll();
+      throw new Error('Not all nock interceptors were used!');
     }
   });
 


### PR DESCRIPTION
/cc @rcebulko 

The linter told me `nock.cleanAll()` is inaccessible code.